### PR TITLE
Added TypeScript Definition

### DIFF
--- a/src/Scripts/jquery.fileDownload.d.ts
+++ b/src/Scripts/jquery.fileDownload.d.ts
@@ -1,0 +1,5 @@
+// Type definitions for jQuery File Download Plugin v1.4.4
+
+interface JQuery {
+    fileDownload(fileUrl: string, options: any);
+}


### PR DESCRIPTION
Adds TypeScript Definition file to allow strongly typed use with TypeScript

Using this locally and thought I'd share it in case anyone else wants to use this plugin with TypeScript.
If a developer does not have TypeScript compile setup this file will be ignored by VisualStudio, if they do it will be used to allow strongly typed use of jquery.fileDownload from within TypeScript code.
